### PR TITLE
changed provider name to ValidatorProvider

### DIFF
--- a/2.0/validation.md
+++ b/2.0/validation.md
@@ -19,7 +19,7 @@ Now in order to make use of Validation provider you need to register it inside `
 
 ```javascript,line-numbers
 const providers = [
-  'adonis-validation-provider/providers/Validator'
+  'adonis-validation-provider/providers/ValidatorProvider'
 ]
 ```
 


### PR DESCRIPTION
Error: Cannot find module 'adonis-validation-provider/providers/Validator' 
but ValidatorProvider works 