### PR TITLE
Fix broken link to dependency injection page

### DIFF
--- a/2.0/ioc-container.md
+++ b/2.0/ioc-container.md
@@ -1,6 +1,6 @@
 # IoC Container
 
-To understand Ioc Container you should know what [Dependency Injection](dependency-injection) is and why it is required. An IoC container is a layer to register and resolve dependencies out of a container and has several benefits when building modern applications.
+To understand Ioc Container you should know what [Dependency Injection](controllers#dependency-injection) is and why it is required. An IoC container is a layer to register and resolve dependencies out of a container and has several benefits when building modern applications.
 
 - [Binding](#binding)
   - [bind](#bind)


### PR DESCRIPTION
There's a link to a non-existent dependency injection page which is broken. This fixes the broken link, pointing it to the Dependency Injection section of the Controllers page.