### PR TITLE
Fix incorrect method name for adding new filters

### DIFF
--- a/2.0/views.md
+++ b/2.0/views.md
@@ -408,7 +408,7 @@ const App = use('App')
 const View = use('View')
 
 App.on('start', function () {
-  View.addFilter('date', function (value, format) {
+  View.filter('date', function (value, format) {
     return moment(value).format(format)
   })
 })


### PR DESCRIPTION
The actual method name to add a new filter is `View.filter`, not `View.addFilter`.