### PR TITLE
Fix error in service providers

### DIFF
--- a/2.0/service-providers.md
+++ b/2.0/service-providers.md
@@ -72,7 +72,7 @@ Next, we need to bind the above class inside the Ioc container and for that we w
 ##### providers/Hello/HelloProvider.js
 
 ```javascript,line-numbers
-'use strict' 
+'use strict'
 
 const ServiceProvider = require('adonis-fold').ServiceProvider
 

--- a/2.0/service-providers.md
+++ b/2.0/service-providers.md
@@ -72,6 +72,8 @@ Next, we need to bind the above class inside the Ioc container and for that we w
 ##### providers/Hello/HelloProvider.js
 
 ```javascript,line-numbers
+'use strict' 
+
 const ServiceProvider = require('adonis-fold').ServiceProvider
 
 class HelloProvider extends ServiceProvider {


### PR DESCRIPTION
Add 'use strict' to prevent error in require-stack:/src/index.js:59