### PR TITLE
Clarify what nodemon really does (no hot-reloading)

### DIFF
--- a/3.0/getting-started/installing.md
+++ b/3.0/getting-started/installing.md
@@ -85,10 +85,11 @@ npm install
 
 ## Starting Server
 
-AdonisJs makes use of [nodemon.io](http://nodemon.io/) to start the development server with hot-reloading.
+AdonisJs makes use of [nodemon](http://nodemon.io/) to automatically restart the server in development.
+
 
 ```bash
-npm run dev // to start the server with hot-reloading
+npm run dev # while developing: start the server with auto restart
 # or
-npm start // without hot-reloading
+npm start # in production
 ```


### PR DESCRIPTION
In PR #21 a note was added to run adonis in dev mode with `npm run dev`, because it will use **hot-reloading with nodemon**.

This isn't true, nodemon just listens to changes and restarts the server. Hot reloading is something completely different. Facebook defines it as follows:

> The idea behind hot reloading is to keep the app running and to inject new versions of the files that you edited at runtime.

I don't want to sound picky :D but it isn't hot reloading and nodemon doesn't say anything about hot reloading, too.