### PR TITLE
Mention that `resources` is an alias for `resource`

### DIFF
--- a/3.0/guides/controllers.md
+++ b/3.0/guides/controllers.md
@@ -101,7 +101,7 @@ Route.get('/users', 'Admin/UserController.index')
 
 CRUD applications are built on the idea of **Creating, Reading, Updating and Deleting** records from a database table.
 
-Since these are very common operations, AdonisJs helps you in defining conventional routes and their Controller actions using a term called `resource`.
+Since these are very common operations, AdonisJs helps you in defining conventional routes and their Controller actions using a term called `resource`. You can also use `resources`, which is an alias for the former.
 
 #### resources(name, Controller)
 ```javascript


### PR DESCRIPTION
I was a little bit confused, while reading the docs. Sometimes `resource` is used in the `routes.js` and sometimes `resources`. I took a look into the framework and found out that both are the same and the former is an alias for the for the later. So to make it other people easier I added this simple note to the docs.