### PR TITLE
Use correct function text() for plaintext

### DIFF
--- a/common-web-tools/04-mail.adoc
+++ b/common-web-tools/04-mail.adoc
@@ -274,7 +274,7 @@ TIP: All popular email clients does support HTML.
 
 [source, javascript]
 ----
-message.html('A plaintext view')
+message.text('A plaintext view')
 ----
 
 ==== watchHtml(body)


### PR DESCRIPTION
In the mail docs a wrong function was used in the plaintext example.

I assume it was a just a copy'n'paste error :)