### PR TITLE
fixed broken url path in tutorial/creating blog posts

### DIFF
--- a/tutorial/05-creating-blog-posts.adoc
+++ b/tutorial/05-creating-blog-posts.adoc
@@ -95,7 +95,7 @@ Quite a lot to cover here. Form builder provides some convenient methods to crea
 
 3. Everything else is a part of standard Form Builder API to create the input fields and the submit button.
 
-Visit link:http://localhost:3333/post/create[http://localhost:3333/post/create, window="_blank"] and you will see a nice looking form to create the posts.
+Visit link:http://localhost:3333/posts/create[http://localhost:3333/posts/create, window="_blank"] and you will see a nice looking form to create the posts.
 
 image:http://res.cloudinary.com/adonisjs/image/upload/v1472841279/create-posts_xgghpo.png[]
 


### PR DESCRIPTION
The URL in the tutorial section for 'Creating Blog Posts' is http://localhost:3333/post/create and does not work. I fixed the url to be http://localhost:3333/posts/create to match the route defined at the top of the page:

Route.get('posts/create', 'PostsController.create')