### PR TITLE
Remove Mandrill ref from the documentation 

### DIFF
--- a/prologue/01-adonisjs-at-a-glance.adoc
+++ b/prologue/01-adonisjs-at-a-glance.adoc
@@ -14,7 +14,7 @@ Below is the list of core features:
 [pretty-list]
 1. Powerful link:https://en.wikipedia.org/wiki/Object-relational_mapping[ORM, window="_blank"] to make secure SQL queries.
 2. API & Session based Authentication System.
-3. Easy way to send emails via SMTP or Web Service (Mmailgun, AWS SES, etc.)
+3. Easy way to send emails via SMTP or Web Service (Mailgun, AWS SES, etc.)
 4. Validate & Sanitise every user's inputs.
 5. Strong emphasis on security.
 6. Extendable application layout.


### PR DESCRIPTION
> On April 27, Mandrill became a paid MailChimp add-on. More information about this transition is in this blog post. 

Since Mandrill isn't supported as a service anymore this addon won't work with this reference.

While the addon hasn't been fixed it would be great to have the documentation pointing only for the working options of the email addon.