### PR TITLE
Documentation for second JWT generate() parameter

### DIFF
--- a/common-web-tools/02-authentication.adoc
+++ b/common-web-tools/02-authentication.adoc
@@ -293,7 +293,7 @@ if (!isLoggedIn) {
 }
 ----
 
-==== generate(user)
+==== generate(user, [customPayload])
 Generates a JWT for a given user.
 
 [source, javascript]

--- a/common-web-tools/02-authentication.adoc
+++ b/common-web-tools/02-authentication.adoc
@@ -302,7 +302,7 @@ const user = yield User.find(1)
 const token = yield request.auth.generate(user)
 ----
 
-The generate function also accepts an optional second parameter that allows you to pass custom details and objects into the JWT for a given user.
+The optional second parameter allows you to pass custom details and objects into the JWT for a given user.
 
 [source, javascript]
 ----

--- a/common-web-tools/02-authentication.adoc
+++ b/common-web-tools/02-authentication.adoc
@@ -302,6 +302,37 @@ const user = yield User.find(1)
 const token = yield request.auth.generate(user)
 ----
 
+The generate function also accepts an optional second parameter that allows you to pass custom details and objects into the JWT for a given user.
+
+[source, javascript]
+----
+const user = yield User.find(1)
+const token = yield request.auth.generate(user, { 
+  username: 'GreatScott',
+  account_type: 'admin'
+})
+----
+
+Which would give you the following in your JWT on the client:
+[source, javascript]
+----
+import jwtDecode from 'jwt-decode'
+const decoded = jwtDecode(data.data.jwt)
+console.log(decoded)
+/* 
+{
+  iat: 1491568810
+  payload: {
+    uid: 1,
+    data: {
+      account_type: "admin",
+      username: "GreatScott"
+    }
+  }
+}
+*/
+----
+
 ==== validate(uid, password)
 Validate user credentials to see if they are valid or not.
 

--- a/common-web-tools/02-authentication.adoc
+++ b/common-web-tools/02-authentication.adoc
@@ -345,8 +345,8 @@ try {
 }
 ----
 
-==== attempt(uid, password)
-Validates the user credentials and generates a JWT if they valid.
+==== attempt(uid, password, [customPayload])
+Validates the user credentials and generates a JWT if the credentials are valid. It can also accept an optional custom payload like within the `generate()` example above.
 
 [source, javascript]
 ----

--- a/common-web-tools/15-ws.adoc
+++ b/common-web-tools/15-ws.adoc
@@ -370,6 +370,14 @@ Emit a message to the originating socket only.
 socket.toMe().emit('greet', 'Hello world')
 ----
 
+#### exceptMe()
+Emit a message to everyone except the originating socket.
+
+[source, javascript]
+----
+socket.exceptMe().emit('user:join', 'User joined!')
+----
+
 #### to(ids)
 Emit a message to specific socket ids only.
 [source, javascript]

--- a/database/04-seeds-and-factories.adoc
+++ b/database/04-seeds-and-factories.adoc
@@ -102,7 +102,7 @@ const User = use('App/Model/User') <1>
 const user = yield User.find(1) <2>
 
 const post = Factory.model('App/Model/Post').make() <3>
-yield User.posts().create(post) <4>
+yield user.posts().create(post) <4>
 ----
 
 <1> Importing user model.

--- a/getting-started/05-routing.adoc
+++ b/getting-started/05-routing.adoc
@@ -32,6 +32,27 @@ Above we defined a route for the *root URL(/)* and attached a closure to it. Her
 1. The closure is an ES2015 generator which means you can make use of the `yield` keyword to perform async operations. Check out this link:https://strongloop.com/strongblog/write-your-own-co-using-es2015-generators/[post, window="_blank"] by Strongloop on generators.
 2. AdonisJs uses the terms `request` and `response` in place of `req` and `res`.
 
+==== middleware(...middleware)
+Define middleware to a single route
+
+.app/Http/routes.js
+[source, javascript]
+----
+Route.get('/authenticated', function * (request, response) {
+  response.send('This route is authenticated')
+}).middleware('auth')
+----
+
+Or add multiple middlewares
+
+.app/Http/routes.js
+[source, javascript]
+----
+Route.get('/secured', function * (request, response) {
+  response.send('This route is authenticated')
+}).middleware(['auth', 'custom'])
+----
+
 == HTTP Verbs
 HTTP verbs also known as HTTP methods defines the type of request. A very classic example of HTTP verbs is using a form where we define the `method` as POST since we want to submit the forms securely to the web server.
 

--- a/lucid/01-lucid.adoc
+++ b/lucid/01-lucid.adoc
@@ -235,7 +235,7 @@ Soft deletes is a term for deleting records by updating a delete timestamp inste
 
 Soft deletes are disabled by default and to enable them you must return a table field name from `deleteTimestamp` getter.
 
-NOTE: You can make use of xref:with_trashed[withTrashed] method to fetch soft deleted rows.
+NOTE: You can make use of xref:withtrashed[withTrashed] method to fetch soft deleted rows.
 
 ==== dateFormat
 Date format specifies the format of date in which timestamps should be saved. Internally models will convert dates to link:http://momentjs.com/[moment.js, window="_blank"] instance. You can define any valid date format supported by momentjs.

--- a/lucid/01-lucid.adoc
+++ b/lucid/01-lucid.adoc
@@ -235,6 +235,8 @@ Soft deletes is a term for deleting records by updating a delete timestamp inste
 
 Soft deletes are disabled by default and to enable them you must return a table field name from `deleteTimestamp` getter.
 
+NOTE: You can make use of xref:with_trashed[withTrashed] method to fetch soft deleted rows.
+
 ==== dateFormat
 Date format specifies the format of date in which timestamps should be saved. Internally models will convert dates to link:http://momentjs.com/[moment.js, window="_blank"] instance. You can define any valid date format supported by momentjs.
 
@@ -682,6 +684,14 @@ const user = yield User.findOrCreate(
   { username: 'virk' },
   { username: 'virk', email: 'virk@adonisjs.com' }
 )
+----
+
+==== withTrashed
+The `withTrashed` method can be used to fetch soft deleted rows.
+
+[source, javascript]
+----
+const users = yield User.query().withTrashed().fetch()
 ----
 
 == Using Transactions

--- a/lucid/02-relationships.adoc
+++ b/lucid/02-relationships.adoc
@@ -208,7 +208,7 @@ Also you choose to save timestamps on the pivot table.
 ----
 class Student extends Lucid {
   courses () {
-    this.belongsToMany('App/Model/Course')->withTimestamps()
+    this.belongsToMany('App/Model/Course').withTimestamps()
   }
 }
 ----


### PR DESCRIPTION
Currently, in the [JWT documentation](https://adonisjs.com/docs/3.2/authentication#_generate_user), there's no documentation of the extra payload that you can add when you're generating a JWT that was completed for adonisjs/adonis-auth#13. This is just a tiny little commit to show that and some sample output on the client side of things.