### PR TITLE
Adding View filters/global: Wait for autoload setup

### DIFF
--- a/views/01-views.adoc
+++ b/views/01-views.adoc
@@ -274,10 +274,14 @@ const ServiceProvider = require('adonis-fold').ServiceProvider
 
 class MyServiceProvider extends ServiceProvider {
 
-  boot () {
-    const View = use('Adonis/Src/View')
-    View.global('time', function () {
-      return new Date().getTime()
+  * boot () {
+    this.app.once('bind:autoload', () => {
+        // We need to wait for the application to bootstrap before we can use `View`
+        const View = use('Adonis/Src/View')
+
+        View.global('time', function () {
+          return new Date().getTime()
+        })
     })
   }
 


### PR DESCRIPTION
We need to wait for autoload to be setup before we can request `View` module when adding filters/globals to Nunjucks.