### PR TITLE
MariaDB Error: No database selected

### DIFF
--- a/database/01-database-setup.adoc
+++ b/database/01-database-setup.adoc
@@ -198,7 +198,7 @@ maria: {
     port: 3306,
     user: 'root',
     password: '',
-    database: 'adonis'
+    db: 'adonis'
   }
 }
 ----


### PR DESCRIPTION
Running migrations will fail using MariaDB driver because of wrong `database` property name in connection settings:
```
Error: create table if not exists `adonis_schema` (`id` int unsigned not null auto_increment primary key, `name` varchar(255), `batch` int, `migration_time` timestamp) - No database selected
```
Changing `database` to `db` fixes the issue.