### PR TITLE
fix(ws): joinRoom and leaveRoom signature

### DIFF
--- a/common-web-tools/15-ws.adoc
+++ b/common-web-tools/15-ws.adoc
@@ -261,7 +261,7 @@ class ChatController {
     this.socket = socket
   }
 
-  * leaveRoom (room) {
+  * leaveRoom (room, body, socket) {
     // Do cleanup if required
   }
 

--- a/common-web-tools/15-ws.adoc
+++ b/common-web-tools/15-ws.adoc
@@ -212,8 +212,8 @@ class ChatController {
     this.socket = socket
   }
 
-  * joinRoom (room) {
-    const user = this.socket.currentUser
+  * joinRoom (room, body, socket) {
+    const user = socket.currentUser
     // throw error to deny a socket from joining room
   }
 }
@@ -265,8 +265,8 @@ class ChatController {
     // Do cleanup if required
   }
 
-  * joinRoom (room) {
-    const user = this.socket.currentUser
+  * joinRoom (room, body, socket) {
+    const user = socket.currentUser
     // throw error to deny a socket from joining room
   }
 }


### PR DESCRIPTION
Update join and leave room signatures as this commit [33ee33ee](https://github.com/adonisjs/adonis-websocket/blob/33ee3ee6637deb845ab8dcbbd66574b823cd79a7/src/Channel/Mixins/Rooms.js).

Using the current docs signature `this.socket.currentUser` will end up getting `undefined`.