### PR TITLE
specify unique validation database entry

### DIFF
--- a/08-cookbooks/01-validator.adoc
+++ b/08-cookbooks/01-validator.adoc
@@ -65,7 +65,7 @@ class UserController {
 
   async store ({ request, session, response }) {
     const rules = {
-      email: 'required|email|unique',
+      email: 'required|email|unique:users,email',
       password: 'required'
     }
 


### PR DESCRIPTION
Without specifying `users,email` in the validation rules, the validation fails.