### PR TITLE
Auth Docs Update

### DIFF
--- a/04-http-lifecycle/10-authentication.adoc
+++ b/04-http-lifecycle/10-authentication.adoc
@@ -77,7 +77,7 @@ module.exports = {
   session: {
     serializer: 'Lucid',
     scheme: 'session',
-    model: 'App/Model/User',
+    model: 'App/Models/User',
     uid: 'email',
     password: 'password'
   }

--- a/04-http-lifecycle/10-authentication.adoc
+++ b/04-http-lifecycle/10-authentication.adoc
@@ -233,7 +233,7 @@ The basic authentication is stateless, where the end-user is supposed to pass th
 ==== check
 Check to see if the user has passed `basic auth` credentials in the request header or not. Also, this method verifies the user existence and their password
 
-NOTE: Set the `Authorization = Basic <credentials>`  header to authenticate the request.
+NOTE: Set the `Authorization = Basic <credentials>`  header to authenticate the request. The credentials are a `base64` encoded string of `uid:password` where `uid` is the `uid` database field designated in the auth config. 
 
 [source, js]
 ----

--- a/04-http-lifecycle/10-authentication.adoc
+++ b/04-http-lifecycle/10-authentication.adoc
@@ -233,7 +233,7 @@ The basic authentication is stateless, where the end-user is supposed to pass th
 ==== check
 Check to see if the user has passed `basic auth` credentials in the request header or not. Also, this method verifies the user existence and their password
 
-NOTE: Set the `Authorization = Bearer <credentials>`  header to authenticate the request.
+NOTE: Set the `Authorization = Basic <credentials>`  header to authenticate the request.
 
 [source, js]
 ----

--- a/04-http-lifecycle/10-authentication.adoc
+++ b/04-http-lifecycle/10-authentication.adoc
@@ -233,14 +233,14 @@ The basic authentication is stateless, where the end-user is supposed to pass th
 ==== check
 Check to see if the user has passed `basic auth` credentials in the request header or not. Also, this method verifies the user existence and their password
 
-NOTE: Set the `Authorization = Basic <credentials>`  header to authenticate the request. The credentials are a `base64` encoded string of `uid:password` where `uid` is the `uid` database field designated in the auth config. 
+NOTE: Set the `Authorization = Basic <credentials>`  header to authenticate the request. The credentials are a `base64` encoded string of `uid:password` where `uid` is the `uid` database field designated in the auth config.
 
 [source, js]
 ----
 try {
   await auth.check()
 } catch (error) {
-  response.send('Credentials missing')
+  response.send(error.message)
 }
 ----
 


### PR DESCRIPTION
Separated this into specific commits to allow you to cherry pick what you'd like. But the following updates are suggested to the docs:

1. Update `App/Model/User` to `App/Models/User` in config docs to keep up with 4.0 convention.
2. Use correct authorization term. The AdonisJS implementation is setup to use "Basic" and not "Bearer" for basic auth schema.
3. Add more info on what the `<credentials>` consists of for newer users of this auth method.
4. Use the correct string in the docs example. The listed try/catch block could fail for any number of auth reasons, not just missing credentials.