### PR TITLE
Removing outdated note

### DIFF
--- a/04-http-lifecycle/12-handling-exceptions.adoc
+++ b/04-http-lifecycle/12-handling-exceptions.adoc
@@ -97,8 +97,6 @@ Output
 ✔ create  app/Exceptions/CustomException.js
 ----
 
-NOTE: Make sure to install `@adonisjs/generic-exceptions` since it is not installed by default.
-
 [source, js]
 ----
 const GE = require('@adonisjs/generic-exceptions')


### PR DESCRIPTION
`@adonisjs/generic-exceptions` is required in `package.json`, so this message is no longer valid.