### PR TITLE
Publish message should be a string

### DIFF
--- a/06-database/05-redis.adoc
+++ b/06-database/05-redis.adoc
@@ -149,11 +149,11 @@ Publish message to a given channel
 
 [source, js]
 ----
-Redis.publish('music', {
+Redis.publish('music', JSON.stringify({
   id: 1,
   title: 'Love me like you do',
   artist: 'Ellie goulding'
-})
+}))
 ----
 
 ==== unsubscribe(channel)


### PR DESCRIPTION
I looked at ioredis and native redis command bindings and found no indication that the message can be an object. 