### PR TITLE
fix(validator): code example was wrong

### DIFF
--- a/08-cookbooks/01-validator.adoc
+++ b/08-cookbooks/01-validator.adoc
@@ -123,7 +123,8 @@ Validate data with defined rules. Optionally, you can define custom link:http://
 const { validate } = use('Validator')
 
 const validation = await validate(data, rules)
-if (!validation.fails()) {
+
+if (validation.fails()) {
   return validation.messages()
 }
 ----


### PR DESCRIPTION
I also believe we should redo this example with a code that use the custom message feature.