### PR TITLE
Used destroy method instead of delete

### DIFF
--- a/04-http-lifecycle/02-routing.adoc
+++ b/04-http-lifecycle/02-routing.adoc
@@ -353,11 +353,11 @@ Since attaching auth middleware to all the routes is not always desired, you can
 Route
   .resource('users', 'UsersController')
   .middleware(new Map([
-    [['store', 'update', 'delete'], ['auth']]
+    [['store', 'update', 'destroy'], ['auth']]
   ]))
 ----
 
-Here we have defined the `auth` middleware on *store*, *update* and *delete* routes.
+Here we have defined the `auth` middleware on *store*, *update* and *destroy* controller methods.
 
 === Resource Formats
 Also, you can define the formats for all the resourceful routes, just like the way you do for a single route or a group of routes.


### PR DESCRIPTION
Resource controllers are created with the `destroy` method, not `delete`, so it usually leads to confusion (like delete routes without middleware!)