### PR TITLE
Error referencing the file name

### DIFF
--- a/02-internals/02-service-providers.adoc
+++ b/02-internals/02-service-providers.adoc
@@ -150,7 +150,7 @@ Finally, we need to register this provider like any other provider inside the `s
 [source, js]
 ----
 const providers = [
-  path.join(__dirname, '..', 'providers', 'Queue/provider')
+  path.join(__dirname, '..', 'providers', 'Queue/Provider')
 ]
 ----
 


### PR DESCRIPTION
it should be  path.join(__dirname, '..', 'providers', 'Queue/Provider') instead of  path.join(__dirname, '..', 'providers', 'Queue/provider')