### PR TITLE
Add "-text" suffix to mail plain text template

### DIFF
--- a/09-cookbooks/04-mail.adoc
+++ b/09-cookbooks/04-mail.adoc
@@ -100,6 +100,8 @@ await Mail.send(['welcome', 'welcome.text'])
 
 The view ending with `.text` is used as the plain text body of the email. In the same way, you can set the mail body for Apple watch.
 
+If you're using edge as template engine, you can algo use `-text` instead of `.text` as the plain text body template.
+
 [source, js]
 ----
 await Mail.send(['welcome', 'welcome.text', 'welcome.watch'])

--- a/09-cookbooks/04-mail.adoc
+++ b/09-cookbooks/04-mail.adoc
@@ -100,7 +100,7 @@ await Mail.send(['welcome', 'welcome.text'])
 
 The view ending with `.text` is used as the plain text body of the email. In the same way, you can set the mail body for Apple watch.
 
-If you're using edge as template engine, you can algo use `-text` instead of `.text` as the plain text body template.
+If you're using edge as template engine, you can also use `-text` instead of `.text` as the plain text body template suffix.
 
 [source, js]
 ----


### PR DESCRIPTION
Since (https://github.com/adonisjs/adonis-mail/pull/12) the user can use "-text" as mail suffix for plain text body template to avoid conflicts with edge template engine and dot notation.