### PR TITLE
Correct query-builder/lucid pagination output example

### DIFF
--- a/06-database/02-query-builder.adoc
+++ b/06-database/02-query-builder.adoc
@@ -470,13 +470,11 @@ NOTE: The output of the `paginate` method is different from the `forPage` method
 [source, javascript]
 ----
 {
-  pages: {
-    total: 0,
-    currentPage: 2,
-    perPage: 10,
-    lastPage: 0,
-  },
-  rows: [{...}]
+  total: '',
+  perPage: '',
+  lastPage: '',
+  page: '',
+  data: [{...}]
 }
 ----
 

--- a/07-lucid/01-model.adoc
+++ b/07-lucid/01-model.adoc
@@ -512,7 +512,7 @@ The return value of `paginate` is not an array of users. Instead, it is an objec
   perPage: '',
   lastPage: '',
   page: '',
-  data: []
+  data: [{...}]
 }
 ----
 


### PR DESCRIPTION
In the current version of the docs, Query Builder is described as having a different pagination output than calling it via the Lucid method. This doesn't appear to be the case.

It currently shows that this is the expected output for the query builder:

```js
return await Database.table('blog_posts').paginate(1)
```

```js
{
  pages: {
    total: 0,
    currentPage: 2,
    perPage: 10,
    lastPage: 0,
  },
  rows: [{...}]
}
```

and the expected output for Lucid pagination is 

```js
return BlogPost
        .query()
        .paginate(1, 5)
```

```js
{
  total: '',
  perPage: '',
  lastPage: '',
  page: '',
  data: []
}
```

The former is incorrect as the actual output does not include a separate object for the pagination meta, although I do believe that this should be the intended functionality, but changing that now would break applications on Adonis 4.1, and might be something to consider in the next major release. 

The actual output for the query builder is:

```js
{
    "total": "10",
    "perPage": 5,
    "page": 1,
    "lastPage": 1,
    "data": [...]
} 
```

which is consistent with the current output of the Lucid function:

```js
{
    "total": "10",
    "perPage": 5,
    "page": 1,
    "lastPage": 1,
    "data": [...]
}
```