### PR TITLE
Update 02-query-builder.adoc

### DIFF
--- a/06-database/02-query-builder.adoc
+++ b/06-database/02-query-builder.adoc
@@ -491,8 +491,8 @@ The `beginTransaction` method returns the transaction object, which can be used 
 const trx = await Database.beginTransaction()
 await trx.insert({username: 'virk'}).into('users')
 
-trx.commit() // insert query will take place on commit
-trx.rollback() // will not insert anything
+await trx.commit() // insert query will take place on commit
+await trx.rollback() // will not insert anything
 ----
 
 ==== transaction


### PR DESCRIPTION
Rollback and commit functions return promise and we should add await or .catch
Maybe we want to get this row using a new query in the line after trx.commit , maybe we get E_MISSING_DATABASE_ROW error if we do not wait for promise (I had this problem)