### PR TITLE
Update basic example to include overwrite option

### DIFF
--- a/06-Digging-Deeper/03-File-Uploads.adoc
+++ b/06-Digging-Deeper/03-File-Uploads.adoc
@@ -34,7 +34,8 @@ Route.post('upload', async ({ request }) => {
   })
 
   await profilePic.move(Helpers.tmpPath('uploads'), {
-    name: 'custom-name.jpg'
+    name: 'custom-name.jpg',
+    overwrite: true
   })
 
   if (!profilePic.moved()) {
@@ -46,7 +47,7 @@ Route.post('upload', async ({ request }) => {
 
 [ol-spaced]
 1. The `request.file` method accepts two arguments, a *field name* and *an object of validations* to be performed, before moving the file.
-2. Next, we call `profilePic.move` method, which attempts to move the file to the defined directory. You can call it with options to save file with a new name.
+2. Next, we call `profilePic.move` method, which attempts to move the file to the defined directory. You can call it with options to save file with a new name and to overwrite the file if needed.
 3. Finally, we check whether the move operation was successful or not using `profilePic.moved()` method and return errors (if any).
 
 == Multiple file uploads


### PR DESCRIPTION
Updates File Update section to include the fact that move() can now receive an option named overwrite to overwrite the file if needed.