### PR TITLE
change types to extnames because size in not exist in codebase.

### DIFF
--- a/06-Digging-Deeper/03-File-Uploads.adoc
+++ b/06-Digging-Deeper/03-File-Uploads.adoc
@@ -29,7 +29,7 @@ const Helpers = use('Helpers')
 
 Route.post('upload', async ({ request }) => {
   const profilePic = request.file('profile_pic', {
-    types: ['image'],
+    extnames: ['jpg', 'png', 'jpeg'],
     size: '2mb'
   })
 
@@ -67,7 +67,7 @@ const Helpers = use('Helpers')
 
 Route.post('upload', async ({ request }) => {
   const profilePics = request.file('profile_pics', {
-    types: ['image'],
+    extnames: ['jpg', 'png', 'jpeg'],
     size: '2mb'
   })
 


### PR DESCRIPTION
Hi @thetutlage 

I checked the codebase and did not see anything about types, I think you change it to extnames.

So it would be better if we fix it in documentations