### PR TITLE
Add css globals to upgrade guide

### DIFF
--- a/01-Preface/02-upgrade-guide.adoc
+++ b/01-Preface/02-upgrade-guide.adoc
@@ -143,6 +143,24 @@ configure({
 })
 ----
 
+== Views
+
+==== css
+
+The `css` global has been changed to `style`. The `css` global is no longer supported
+
+Earlier
+[source, edge]
+----
+{{ css('style') }}
+----
+
+Now
+[source, edge]
+----
+{{ style('style') }}
+----
+
 == Lucid
 Previously, date formatting was inconsistent with newly created records and existing records.
 


### PR DESCRIPTION
One of the breaking changes in the move from [4.0](https://adonisjs.com/docs/4.0/) to [4.1](https://adonisjs.com/docs/4.1) was the replacement of the `{{ css('style') }}` with `{{ style('style') }}` format for creating `link` tags to css files.

`css` was renamed [here](https://github.com/adonisjs/adonis-framework/commit/e9e67636369fe5574938f20e482851fe9eca041b#diff-8caf10debdcb4f3064ecacf3e56f4dc3R35) in adonisjs/adonis-framework/#827 . The method was then removed [here](https://github.com/adonisjs/adonis-framework/commit/cd0e6835691db3a4a8b502d3ab9bb8eb2cef85c0#diff-8caf10debdcb4f3064ecacf3e56f4dc3) and was a breaking change so I think it definitely makes sense to have this in the `4.1` documents for migrating from `4.0`. I've also gone ahead and [made sure]( that this covers all `View` [changes](e9e67636369fe5574938f20e482851fe9eca041b) from `4.0` to [`4.1`](https://github.com/adonisjs/adonis-framework/commit/e7c895f6f33c83c94293d825e55a42907085b612)