### PR TITLE
add debug option to documentation for websocket client api

### DIFF
--- a/09-WebSockets/04-Client-API.adoc
+++ b/09-WebSockets/04-Client-API.adoc
@@ -64,6 +64,7 @@ ws.connect()
 | reconnectionDelay | *1000* | How long to wait, before reconnecting. The value will be used as `n x delay`, where `n` is the current value of reconnection attempts.
 | query | *null* | Query string to passed to the connection URL. You can pass an object
 | encoder | *JsonEncoder* | The encoder to be used. The same encoder will be required on the server too.
+| debug | `true` if `NODE_ENV` is not set to `production` | `log` statements used for debugging and outputted to `console.log`
 |===
 
 It is recommended to listen for `open` and `close` events, to manage your application state properly.


### PR DESCRIPTION
To be merged if adonisjs/adonis-websocket-client#53 is merged. I also wasn't sure if I should make another pr targeted at `4.2`(please see #316).