### PR TITLE
Update 03-Migrations.adoc

### DIFF
--- a/07-Database/03-Migrations.adoc
+++ b/07-Database/03-Migrations.adoc
@@ -292,7 +292,7 @@ Only creates the extension if it does not exists, otherwise silently ignores the
 ----
 class UserSchema {
   up () {
-    this.createIfNotExists('postgis')
+    this.createExtensionIfNotExists('postgis')
   }
 }
 ----


### PR DESCRIPTION
createExtensionIfNotExists example fixed with the correct function name