### PR TITLE
adding driver in the list of special method

### DIFF
--- a/06-Digging-Deeper/04-File-Storage.adoc
+++ b/06-Digging-Deeper/04-File-Storage.adoc
@@ -122,7 +122,7 @@ await Drive.copy('hi.txt', 'hello.txt')
 ----
 
 == S3 specific methods
-Below is the list of methods that works for `s3` driver only.
+Below is the list of methods that works for `s3` driver and `spaces` driver of DigitalOcean Spaces only.
 
 ==== getObject(location, params)
 Get s3 object for a given file. Params is the list of link:http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#getObject-property[S3 params].


### PR DESCRIPTION
getObject(location, params)
getUrl(location, [bucket])
getSignedUrl(location, expiry = 900, params) 
methods can be used with `spaces` driver. DigitalOcean provide the same possibility.