### PR TITLE
Fix wrong sequence of traits

### DIFF
--- a/10-testing/02-HTTP-Tests.adoc
+++ b/10-testing/02-HTTP-Tests.adoc
@@ -207,8 +207,8 @@ Also, you can authenticate users beforehand by using the `Auth/Client` trait.
 const { test, trait } = use('Test/Suite')('Post')
 
 trait('Test/ApiClient')
-trait('Session/Client')
 trait('Auth/Client')
+trait('Session/Client')
 
 test('get list of posts', async ({ client }) => {
   const user = await User.find(1)


### PR DESCRIPTION
An error has occured when the wrong sequence of trait is followed:

```
Error: Make sure to register session trait after the auth trait. It should be in following order
trait('Auth/Client')
trait('Session/Client')
```