### PR TITLE
Explicitly tell the user to include the trait

### DIFF
--- a/10-testing/02-HTTP-Tests.adoc
+++ b/10-testing/02-HTTP-Tests.adoc
@@ -202,6 +202,8 @@ test('get list of posts', async ({ client }) => {
 == Authentication
 Also, you can authenticate users beforehand by using the `Auth/Client` trait.
 
+IMPORTANT: Define the `trait` in the `const { test, trait } = use('Test/Suite')('Post')` block to prevent error
+
 [source, js]
 ----
 const { test, trait } = use('Test/Suite')('Post')


### PR DESCRIPTION
Most users are failing to include this and have to resort to Stockoverflow for assistance when it could alrady be explicitly state in the docs. 😃 

> ReferenceError: trait is not defined