### PR TITLE
Added missing information about eager loading

### DIFF
--- a/08-Lucid-ORM/05-Relationships.adoc
+++ b/08-Lucid-ORM/05-Relationships.adoc
@@ -563,6 +563,19 @@ const users = await User
 
 In the example above, a `where` constraint is added to the `posts` relation while eager loading `posts.comments` at the same time.
 
+=== Retrieving loaded models data
+To retrieve the loaded data you must call the `getRelated` method:
+
+[source, js]
+----
+const user = await User
+  .query()
+  .with('posts')
+  .fetch()
+
+const posts = user.getRelated('posts')
+----
+
 == Lazy Eager Loading
 To load relationships *after* already fetching data, use the `load` method.
 
@@ -591,6 +604,18 @@ await user.loadMany({
   posts: (builder) => builder.where('is_published', true),
   profiles: null
 })
+----
+
+=== Retrieving loaded models data
+To retrieve the loaded data you must call the `getRelated` method:
+
+[source, js]
+----
+const user = await User.find(1)
+await user.loadMany(['posts', 'profiles'])
+
+const posts = user.getRelated('posts')
+const profiles = user.getRelated('profiles')
 ----
 
 == Filtering Data


### PR DESCRIPTION
There wasn't any reference about how to retrieve the loaded data for eager loading and lazy eager loading.
Now the `getRelated` method is referenced to show how to retrive loaded data.