### PR TITLE
We can not use this in arrow functions. This example has mislead me 

### DIFF
--- a/06-Digging-Deeper/03-Extending-the-Core.adoc
+++ b/06-Digging-Deeper/03-Extending-the-Core.adoc
@@ -75,7 +75,7 @@ For example, if a macro was defined like so:
 const Response = use('Adonis/Src/Response')
 const Request = use('Adonis/Src/Request')
 
-Response.macro('sendStatus', (status) => {
+Response.macro('sendStatus', function (status) {
   this.status(status).send(status)
 })
 ----


### PR DESCRIPTION
So the bug I opened  before was rather located in [this page](https://adonisjs.com/docs/4.1/extending-adonisjs#_adding_macrosgetters) :)