### PR TITLE
Example 'Broadcast Anywhere' improved

### DIFF
--- a/09-WebSockets/03-Server-API.adoc
+++ b/09-WebSockets/03-Server-API.adoc
@@ -125,10 +125,11 @@ class UserController {
   async register () {
     // ...
 
-    Ws
-      .getChannel('subscriptions')
-      .topic('subscriptions')
-      .broadcast('new:user')
+    const topic = Ws.getChannel('subscriptions').topic('subscriptions')
+    // if no one is listening, so the `topic('subscriptions')` method will return `null`
+    if(topic){
+      topic.broadcast('new:user')
+    }
   }
 }
 ----


### PR DESCRIPTION
I've updated the broadcast anywhere example for a more convenient use case, because sometimes when you try to broadcast for a specific topic and this topic has no listeners, you'll get an unknown error, caused because the return of `topic` method is `null`.