### PR TITLE
docs(lucid): transaction.rollback typo fix

### DIFF
--- a/08-Lucid-ORM/01-Getting-Started.adoc
+++ b/08-Lucid-ORM/01-Getting-Started.adoc
@@ -805,7 +805,7 @@ await userRole.load('user', null, trx)
 
 await trx.commit()
 // if something gone wrong
-await trx.rollback
+await trx.rollback()
 ----
 
 == Boot Cycle


### PR DESCRIPTION
Fixes issue #376 