### PR TITLE
Included instructions on using RS256 algorithm in JWT authentication

### DIFF
--- a/05-Security/02-Authentication.adoc
+++ b/05-Security/02-Authentication.adoc
@@ -287,7 +287,7 @@ try {
 ----
 
 == JWT
-link:https://jwt.io/[JWT authentication, window="_blank"] is an industry standard to implement stateless authentication via string tokens. 
+link:https://jwt.io/[JWT authentication, window="_blank"] is an industry standard to implement stateless authentication via string tokens.
 
 AdonisJs supports JWT tokens out of the box via its *jwt* authenticator.
 
@@ -317,13 +317,35 @@ module.exports = {
 [options="header"]
 |====
 | Key | Values | Default Value | Description
-| algorithm | `HS256`, `HS384` | `HS256` | Algorithm used to generate tokens.
+| algorithm | `HS256`, `HS384`, `RS256` | `HS256` | Algorithm used to generate tokens.
 | expiresIn | Valid time in seconds or link:https://github.com/rauchg/ms.js[ms string, window="_blank"] | null | When to expire tokens.
 | notBefore | Valid time in seconds or link:https://github.com/rauchg/ms.js[ms string, window="_blank"] | null | Minimum time to keep tokens valid.
 | audience |  String | null  | `aud` claim.
 | issuer |  Array or String | null | `iss` claim.
 | subject | String | null | `sub` claim.
+| public | String | null | `public` key to verify the token encrypted with RSA algorithm.
 |====
+
+----
+  To secure JWT using `RS256` asymmetric algorithm, you need to explictly provide `algorithm` option and set it to `RS256`.
+  You must provide your `private key` via `secret` option which will be used by the framework to sign your JWT.
+  And you must provide your `public key` via `public` option, which will be used by the framework
+  to verify the JWT.
+
+  const fs = use("fs");
+  module.exports = {
+    authenticator: 'jwt',
+    jwt: {
+      //...
+      options: {
+        algorithm: 'RS256',
+        secret: fs.readFileSync('absolute-path-to-your-private-key-file'),
+        public: fs.readFileSync('absolute-path-to-your-public-key-file'),
+        // For additional options, see the table above...
+      }
+    }
+  }
+----
 
 === JWT Methods
 


### PR DESCRIPTION
This pull request include the instructions to use asymmetric algorithms such as RS256 with JWT authentication scheme. The document update is in response to the merged [pull request 138](https://github.com/adonisjs/adonis-auth/pull/138) in **adonis-auth** repository. 