### PR TITLE
Added a note for response.cookie.

### DIFF
--- a/04-Basics/05-Response.adoc
+++ b/04-Basics/05-Response.adoc
@@ -146,6 +146,8 @@ response.type('application/json')
 == Cookies
 Use the following methods to set/remove response cookies.
 
+NOTE: You might have trouble setting cookie values from a different domain using XMLHttpRequest. For more details, please refer to this https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/withCredentials[link].
+
 ==== cookie
 Set a cookie value:
 


### PR DESCRIPTION
This is a proposed change to the Adonis documentation. This could save time for people trying to set a cookie from a different domain. It took me a while to understand what was happening. It would have been great if I had just read it in Adonis official documentation.