### PR TITLE
Add getId() to social auth docs

### DIFF
--- a/06-Digging-Deeper/08-Social-Authentication.adoc
+++ b/06-Digging-Deeper/08-Social-Authentication.adoc
@@ -192,13 +192,21 @@ NOTE: The `accessSecret` parameter is required when the *OAuth 1* protocol is us
 == User API
 Below is the list of available methods on an link:https://github.com/adonisjs/adonis-ally/blob/develop/src/AllyUser.js[AllyUser, window="_blank"] instance.
 
-==== getName
-Returns the user name:
+==== getId
+Returns the user id:
 
 [source, js]
 ----
 const user = await ally.driver('facebook').getUser()
 
+user.getId()
+----
+
+==== getName
+Returns the user name:
+
+[source, js]
+----
 user.getName()
 ----
 


### PR DESCRIPTION
As mentioned here #389, it seems `getId()` is missing from 4.1 docs. This PR related about that issue.