### PR TITLE
:pencil2: Remove unused const keyword

### DIFF
--- a/05-Security/02-Authentication.adoc
+++ b/05-Security/02-Authentication.adoc
@@ -525,7 +525,7 @@ Assuming the user is logged in using the `session` authenticator, we can generat
 // loggedin user via sessions
 const user = auth.user
 
-const auth
+auth
   .authenticator('jwt')
   .generate(user)
 ----

--- a/06-Digging-Deeper/03-File-Uploads.adoc
+++ b/06-Digging-Deeper/03-File-Uploads.adoc
@@ -160,7 +160,7 @@ When upload validation fails, the link:https://github.com/adonisjs/adonis-bodypa
 
 NOTE: The link:https://github.com/adonisjs/adonis-bodyparser/blob/develop/src/Multipart/FileJar.js[FileJar, window="_blank"] `errors` method returns an *array* of errors.
 
-Are few example error objects are listed below.
+A few example error objects are list below.
 
 ==== Type error
 


### PR DESCRIPTION
I removed the `const` keyword that was being used incorrectly in the Switching authenticators section.
Because of the way `auth.generate()` is used in other places of the documentation, i assumed it was a typo.