### PR TITLE
Correct behavior of count()

### DIFF
--- a/07-Database/02-Query-Builder.adoc
+++ b/07-Database/02-Query-Builder.adoc
@@ -539,14 +539,14 @@ const count = await Database
   .from('users')
   .count()                                      // returns array
 
-const total = count[0]['count(*)']              // returns number
+const total = count[0]['count']              // returns number
 
 // COUNT A COLUMN
 const count = await Database
   .from('users')
   .count('id')                                  // returns array
 
-const total = count[0]['count("id")']           // returns number
+const total = count[0]['count']           // returns number
 
 // COUNT COLUMN AS NAME
 const count = await Database
@@ -565,7 +565,7 @@ const count = await Database
   .from('users')
   .countDistinct('id')                          // returns array
 
-const total = count[0]['count(distinct "id")']  // returns number
+const total = count[0]['count']  // returns number
 ----
 
 ==== min


### PR DESCRIPTION
Based on my tests, using count() without defining a alias, will always result in a array in a key "count" inside, not count('*') nor count('id'), etc.

I'm using PostgreSQL 12. Sorry if I'm wrong or didn't  enough tests.