### PR TITLE
Update 05-Response.adoc - Add details on base64 encoding for plainCookie

### DIFF
--- a/04-Basics/05-Response.adoc
+++ b/04-Basics/05-Response.adoc
@@ -172,6 +172,7 @@ In that case, may want to set a plain cookie instead:
 // not signed or encrypted
 response.plainCookie('cartTotal', 20)
 ----
+> Do note, the value is still JSON.stringified and converted to base64 encoded string to avoid encoding issues.
 
 == Redirects
 Use one of the following methods to redirect requests to a different URL.


### PR DESCRIPTION
Took the code comments from the [AdonisJS HTTP Server](https://github.com/adonisjs/http-server/blob/bd3ccdd5578b1240c1503fb987052de95946a952/src/Cookie/Serializer/index.ts#L53-L54) to help clarify some of the documentation for future users.