### PR TITLE
docs/revise-10-testing/01-getting-started.adco-functional-test-example

### DIFF
--- a/10-testing/01-Getting-Started.adoc
+++ b/10-testing/01-Getting-Started.adoc
@@ -64,6 +64,7 @@ For example, you might programmatically open a browser and interact with various
 ----
 const { test, trait } = use('Test/Suite')('Example functional test')
 trait('Test/Browser')
+trait('Test/Session')
 
 test('validate user details', async ({ browser }) => {
   const page = await browser.visit('/')


### PR DESCRIPTION
Added fix which resolves TypeError on page.session object when running functional test example as per issue https://github.com/adonisjs/docs/issues/417